### PR TITLE
Fix spelling of Rijndael in API

### DIFF
--- a/pprp/__init__.py
+++ b/pprp/__init__.py
@@ -3,8 +3,8 @@ __version__ = '0.2.6'
 import pprp.adapters
 
 from pprp.adapters import \
-    rjindael_encrypt_gen, \
-    rjindael_decrypt_gen
+    rijndael_encrypt_gen, \
+    rijndael_decrypt_gen
 
 from pprp.source import \
     file_source_gen, \
@@ -22,3 +22,7 @@ import pprp.crypto
 pprp.adapters.rijndael_cls = pprp.crypto.rijndael
 
 from pprp.utility import trim_pkcs7_padding
+
+# Backwards-compatibility shims
+rjindael_encrypt_gen = rijndael_encrypt_gen
+rjindael_decrypt_gen = rijndael_decrypt_gen

--- a/pprp/adapters.py
+++ b/pprp/adapters.py
@@ -7,7 +7,7 @@ _logger = logging.getLogger(__name__)
 # This will be assigned from the top of the "rijndael" package.
 rijndael_cls = None
 
-def rjindael_encrypt_gen(key, s, block_size=pprp.config.DEFAULT_BLOCK_SIZE_B):
+def rijndael_encrypt_gen(key, s, block_size=pprp.config.DEFAULT_BLOCK_SIZE_B):
     r = rijndael_cls(key, block_size=block_size)
 
     padded = False
@@ -29,7 +29,7 @@ def rjindael_encrypt_gen(key, s, block_size=pprp.config.DEFAULT_BLOCK_SIZE_B):
         block = (chr(block_size) * block_size).encode('ASCII')
         yield r.encrypt(block)
 
-def rjindael_decrypt_gen(key, s, block_size=pprp.config.DEFAULT_BLOCK_SIZE_B):
+def rijndael_decrypt_gen(key, s, block_size=pprp.config.DEFAULT_BLOCK_SIZE_B):
     r = rijndael_cls(key, block_size=block_size)
 
     i = 0

--- a/pprp/resources/README.md
+++ b/pprp/resources/README.md
@@ -50,10 +50,10 @@ key = pprp.pbkdf2(passphrase, salt, key_size)
 sg = pprp.data_source_gen(data_bytes)
 
 # Feed the source into the encryptor.
-eg = pprp.rjindael_encrypt_gen(key, sg)
+eg = pprp.rijndael_encrypt_gen(key, sg)
 
 # Feed the encryptor into the decryptor.
-dg = pprp.rjindael_decrypt_gen(key, eg)
+dg = pprp.rijndael_decrypt_gen(key, eg)
 
 # Sink the output into an IO-stream.
 decrypted = pprp.decrypt_sink(dg)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -19,10 +19,10 @@ class TestCrypto(unittest.TestCase):
         sg = pprp.data_source_gen(data_bytes)
 
         # Feed the source into the encryptor.
-        eg = pprp.rjindael_encrypt_gen(key, sg)
+        eg = pprp.rijndael_encrypt_gen(key, sg)
 
         # Feed the encryptor into the decryptor.
-        dg = pprp.rjindael_decrypt_gen(key, eg)
+        dg = pprp.rijndael_decrypt_gen(key, eg)
 
         # Sink the output into an IO-stream.
         decrypted = pprp.decrypt_sink(dg)


### PR DESCRIPTION
Since existing code will be calling this with the old name, I've added aliases to provide backwards compatibility.