### PR TITLE
Stop installing test dependencies for regular package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
       include_package_data=True,
       zip_safe=False,
       install_requires=install_requires,
+      tests_require=tests_require,
       package_data={
             'pprp': [
                   'resources/README.md',

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,10 @@ _APP_PATH = os.path.dirname(pprp.__file__)
 with open(os.path.join(_APP_PATH, 'resources', 'README.md')) as f:
       long_description = ''.join(f)
 
+install_requires = []
+
 with open(os.path.join(_APP_PATH, 'resources', 'requirements.txt')) as f:
-      install_requires = list(map(lambda s: s.strip(), f))
+      tests_require = list(map(lambda s: s.strip(), f))
 
 description = \
       "A pure-Python Rijndael (AES) and PBKDF2 library. Python 2.7 and " \


### PR DESCRIPTION
Avoid installing the test dependencies for regular package installation.

I'm fairly new to python packaging, so I'm not sure if this is the best way to solve this.

Fixes #8.

(If I try this with `poetry` against the git dependency from the fork, then I only get the `pprp` package, but I don't know if I've broken any of ways things would be installed to run tests.)